### PR TITLE
Update NXDN2DMR.cpp

### DIFF
--- a/NXDN2DMR/NXDN2DMR.cpp
+++ b/NXDN2DMR/NXDN2DMR.cpp
@@ -323,6 +323,10 @@ int CNXDN2DMR::run()
 			LogMessage("XLX, Linking to reflector XLX%03u, module %s", m_xlxrefl, m_xlxmodule.c_str());
 			m_xlxConnected = true;
 		}
+		else if (!m_dmrNetwork->isConnected() && !m_xlxmodule.empty() && m_xlxConnected) {
+			LogMessage("XLX, Disconnected from reflector XLX%03u, module %s", m_xlxrefl, m_xlxmodule.c_str());
+			m_xlxConnected = false;
+		}
 
 		unsigned int len = 0;
 		while ((len = m_nxdnNetwork->read(buffer)) > 0U) {


### PR DESCRIPTION
Add the catch to check when the XLX isn't linked, without this if an XLX you are connected to restarts, NXDN2DMR will not re-connect to the XLX module.
This code is taken from YSF2DMR where this problem does not exist.